### PR TITLE
Added support for sockets and mysqld_multi instances

### DIFF
--- a/backup/xtrabackup.sh
+++ b/backup/xtrabackup.sh
@@ -21,6 +21,7 @@ else
 cat << EOF > $CONFIG_FILE
 MYSQL_USER="$(whoami)"
 MYSQL_PASS=
+MYSQL_SOCKET="/var/run/mysqld/mysqld.sock"
 MYSQL_DATA_DIR=/var/lib/mysql/
 BACKUPS_DIRECTORY=$HOME/mysql-backups
 MAX_BACKUP_CHAINS=8
@@ -51,7 +52,7 @@ INNOBACKUPEX_COMMAND="$(which nice) -n 15 $IONICE_COMMAND $INNOBACKUPEX"
 RSYNC_COMMAND="$(which nice) -n 15 $IONICE_COMMAND  $(which rsync)"
 
 full_backup () {
-	$INNOBACKUPEX_COMMAND --slave-info --user="$MYSQL_USER" --password="$MYSQL_PASS" "$FULLS_DIRECTORY"
+	$INNOBACKUPEX_COMMAND --slave-info --socket=${MYSQL_SOCKET} --user="$MYSQL_USER" --password="$MYSQL_PASS" "$FULLS_DIRECTORY"
 
 	NEW_BACKUP_DIR=$(find $FULLS_DIRECTORY -mindepth 1 -maxdepth 1 -type d -exec ls -dt {} \+ | head -1)
 
@@ -61,7 +62,7 @@ full_backup () {
 incremental_backup () {
 	LAST_BACKUP=${LAST_CHECKPOINTS%/xtrabackup_checkpoints}
 
-	$INNOBACKUPEX_COMMAND --slave-info --user="$MYSQL_USER" --password="$MYSQL_PASS" --incremental --incremental-basedir="$LAST_BACKUP" "$INCREMENTALS_DIRECTORY"
+	$INNOBACKUPEX_COMMAND --slave-info --socket=${MYSQL_SOCKET} --user="$MYSQL_USER" --password="$MYSQL_PASS" --incremental --incremental-basedir="$LAST_BACKUP" "$INCREMENTALS_DIRECTORY"
 
 	NEW_BACKUP_DIR=$(find $INCREMENTALS_DIRECTORY -mindepth 1 -maxdepth 1 -type d -exec ls -dt {} \+ | head -1)
 	cp $LAST_BACKUP/backup.chain $NEW_BACKUP_DIR/

--- a/backup/xtrabackup.sh
+++ b/backup/xtrabackup.sh
@@ -11,8 +11,11 @@ fail () {
 
 INNOBACKUPEX=$(which innobackupex)
 [ -f "$INNOBACKUPEX" ] || die "innobackupex script not found - please ensure xtrabackup is installed before proceeding."
-
-CONFIG_FILE=$HOME/.xtrabackup.config
+if [ -n "$2" ]; then 
+	CONFIG_FILE="${2}"
+else
+	CONFIG_FILE=$HOME/.xtrabackup.config
+fi
 
 if [ -f $CONFIG_FILE ]; then
 	echo -e "Loading configuration from $CONFIG_FILE."

--- a/backup/xtrabackup.sh
+++ b/backup/xtrabackup.sh
@@ -33,7 +33,7 @@ fi
 
 [ -d $MYSQL_DATA_DIR ] || die "Please ensure the MYSQL_DATA_DIR setting in the configuration file points to the directory containing the MySQL databases."
 [ -n "$MYSQL_USER" -a -n "$MYSQL_PASS" ] || die "Please ensure MySQL username and password are properly set in the configuration file."
-if [ -n ${DEFAULTS_GROUP} ];then  DEFAULTS_GROUP="--defaults-group=${DEFAULTS_GROUP}"; fi
+if [ -n "${DEFAULTS_GROUP}" ]; then  DEFAULTS_GROUP="--defaults-group=${DEFAULTS_GROUP}"; fi
 
 FULLS_DIRECTORY=$BACKUPS_DIRECTORY/full
 INCREMENTALS_DIRECTORY=$BACKUPS_DIRECTORY/incr

--- a/backup/xtrabackup.sh
+++ b/backup/xtrabackup.sh
@@ -33,7 +33,7 @@ fi
 
 [ -d $MYSQL_DATA_DIR ] || die "Please ensure the MYSQL_DATA_DIR setting in the configuration file points to the directory containing the MySQL databases."
 [ -n "$MYSQL_USER" -a -n "$MYSQL_PASS" ] || die "Please ensure MySQL username and password are properly set in the configuration file."
-[ -n ${DEFAULTS_GROUP} ] || DEFAULTS_GROUP="--defaults-group=$DEFAULTS_GROUP"
+if [ -n ${DEFAULTS_GROUP} ];then  DEFAULTS_GROUP="--defaults-group=${DEFAULTS_GROUP}"; fi
 
 FULLS_DIRECTORY=$BACKUPS_DIRECTORY/full
 INCREMENTALS_DIRECTORY=$BACKUPS_DIRECTORY/incr


### PR DESCRIPTION
Subject says it all. Added support for the xtrabackup parameters 'socket' and 'defaults-group'. Mostly used by mysqld_multi deployments
